### PR TITLE
Upgrade ortools in requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,5 @@
-absl-py==2.1.0
 numpy==1.24.4
 ortools==9.9.3963
-protobuf==5.26.1
 scipy==1.10.1
 antlr4-python3-runtime==4.13.1
 PyYAML~=6.0.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
-absl-py==1.4.0
+absl-py==2.1.0
 numpy==1.24.4
-ortools==9.6.2534
-protobuf==4.23.3
+ortools==9.9.3963
+protobuf==5.26.1
 scipy==1.10.1
 antlr4-python3-runtime==4.13.1
 PyYAML~=6.0.1


### PR DESCRIPTION
Require a higher version of ortools in `requirements.txt` to make Xpress available