### PR TITLE
Rename input components to input study

### DIFF
--- a/src/andromede/input_converter/src/converter.py
+++ b/src/andromede/input_converter/src/converter.py
@@ -23,7 +23,7 @@ from andromede.input_converter.src.utils import (
 from andromede.study.parsing import InputStudy
 
 
-class StudyConverter:
+class AntaresStudyConverter:
     def __init__(self, study_path: Optional[Path]):
         """
         Initialize processor

--- a/src/andromede/input_converter/src/converter.py
+++ b/src/andromede/input_converter/src/converter.py
@@ -20,8 +20,7 @@ from andromede.input_converter.src.utils import (
     convert_area_to_component_list,
     resolve_path,
 )
-
-from andromede.study.parsing import InputComponents
+from andromede.study.parsing import InputStudy
 
 
 class StudyConverter:
@@ -32,10 +31,10 @@ class StudyConverter:
         self.study_path = resolve_path(study_path) if study_path else None
         self.study: Study = read_study_local(self.study_path) if self.study_path else None  # type: ignore
 
-    def convert_study_to_input_components(self) -> InputComponents:
+    def convert_study_to_input_study(self) -> InputStudy:
         areas = self.study.read_areas()
         area_components = convert_area_to_component_list(areas)
-        return InputComponents(nodes=area_components)
+        return InputStudy(nodes=area_components)
 
     def validate_with_pydantic(
         self, data: dict, model_class: type[BaseModel]

--- a/src/andromede/main/main.py
+++ b/src/andromede/main/main.py
@@ -55,7 +55,7 @@ def input_database(study_path: Path, timeseries_path: Optional[Path]) -> DataBas
         return build_data_base(parse_yaml_components(comp), timeseries_path)
 
 
-def input_components(study_path: Path, model: Library) -> NetworkComponents:
+def input_study(study_path: Path, model: Library) -> NetworkComponents:
     with study_path.open() as comp:
         return resolve_components_and_cnx(parse_yaml_components(comp), model)
 
@@ -64,8 +64,8 @@ def main_cli() -> None:
     parsed_args = parse_cli()
 
     models = input_models(parsed_args.models_path)
-    components = input_components(parsed_args.components_path, models)
-    consistency_check(components.components, models.models)
+    study = input_study(parsed_args.components_path, models)
+    consistency_check(study.components, models.models)
 
     try:
         database = input_database(
@@ -77,7 +77,7 @@ def main_cli() -> None:
             f"An error occurred while importing time series."
         )
 
-    network = build_network(components)
+    network = build_network(study)
 
     timeblock = TimeBlock(1, list(range(parsed_args.duration)))
     scenario = parsed_args.nb_scenarios

--- a/src/andromede/study/parsing.py
+++ b/src/andromede/study/parsing.py
@@ -22,9 +22,9 @@ from pydantic import BaseModel, Field
 from yaml import safe_load
 
 
-def parse_yaml_components(input_components: typing.TextIO) -> "InputComponents":
-    tree = safe_load(input_components)
-    return InputComponents.model_validate(tree["study"])
+def parse_yaml_components(input_study: typing.TextIO) -> "InputStudy":
+    tree = safe_load(input_study)
+    return InputStudy.model_validate(tree["study"])
 
 
 def parse_scenario_builder(file: Path) -> pd.DataFrame:
@@ -66,7 +66,7 @@ class InputComponent(BaseModel):
         alias_generator = _to_kebab
 
 
-class InputComponents(BaseModel):
+class InputStudy(BaseModel):
     nodes: List[InputComponent] = Field(default_factory=list)
     components: List[InputComponent] = Field(default_factory=list)
     connections: List[InputPortConnections] = Field(default_factory=list)

--- a/src/andromede/study/resolve_components.py
+++ b/src/andromede/study/resolve_components.py
@@ -32,11 +32,7 @@ from andromede.study.data import (
     TimeScenarioSeriesData,
     load_ts_from_txt,
 )
-from andromede.study.parsing import (
-    InputComponent,
-    InputComponents,
-    InputPortConnections,
-)
+from andromede.study.parsing import InputComponent, InputPortConnections, InputStudy
 
 
 @dataclass(frozen=True)
@@ -59,7 +55,7 @@ def network_components(
 
 
 def resolve_components_and_cnx(
-    input_comp: InputComponents, library: Library
+    input_comp: InputStudy, library: Library
 ) -> NetworkComponents:
     """
     Resolves:
@@ -111,14 +107,14 @@ def _get_component_by_id(
 
 
 def consistency_check(
-    input_components: Dict[str, Component], input_models: Dict[str, Model]
+    input_study: Dict[str, Component], input_models: Dict[str, Model]
 ) -> bool:
     """
     Checks if all components in the Components instances have a valid model from the library.
     Returns True if all components are consistent, raises ValueError otherwise.
     """
     model_ids_set = input_models.keys()
-    for component_id, component in input_components.items():
+    for component_id, component in input_study.items():
         if component.model.id not in model_ids_set:
             raise ValueError(
                 f"Error: Component {component_id} has invalid model ID: {component.model.id}"
@@ -141,9 +137,7 @@ def build_network(comp_network: NetworkComponents) -> Network:
     return network
 
 
-def build_data_base(
-    input_comp: InputComponents, timeseries_dir: Optional[Path]
-) -> DataBase:
+def build_data_base(input_comp: InputStudy, timeseries_dir: Optional[Path]) -> DataBase:
     database = DataBase()
 
     for comp in input_comp.components:
@@ -188,7 +182,7 @@ def _resolve_scenarization(
 
 
 def build_scenarized_data_base(
-    input_comp: InputComponents,
+    input_comp: InputStudy,
     scenario_builder_data: pd.DataFrame,
     timeseries_dir: Optional[Path],
 ) -> DataBase:

--- a/tests/input_converter/test_converter.py
+++ b/tests/input_converter/test_converter.py
@@ -12,15 +12,15 @@
 
 
 from andromede.input_converter.src.converter import StudyConverter
-from andromede.study.parsing import InputComponent, InputComponents
+from andromede.study.parsing import InputComponent, InputStudy
 
 
 class TestConverter:
-    def test_convert_area_to_input_components(self, local_study_w_areas):
+    def test_convert_area_to_input_study(self, local_study_w_areas):
         converter = StudyConverter(study_path=None)
         converter.study = local_study_w_areas
-        area_components = converter.convert_study_to_input_components()
-        expected_area_components = InputComponents(
+        area_components = converter.convert_study_to_input_study()
+        expected_area_components = InputStudy(
             nodes=[
                 InputComponent(id="fr", model="area", parameters=None),
                 InputComponent(id="it", model="area", parameters=None),

--- a/tests/input_converter/test_converter.py
+++ b/tests/input_converter/test_converter.py
@@ -11,13 +11,13 @@
 # This file is part of the Antares project.
 
 
-from andromede.input_converter.src.converter import StudyConverter
+from andromede.input_converter.src.converter import AntaresStudyConverter
 from andromede.study.parsing import InputComponent, InputStudy
 
 
 class TestConverter:
     def test_convert_area_to_input_study(self, local_study_w_areas):
-        converter = StudyConverter(study_path=None)
+        converter = AntaresStudyConverter(study_path=None)
         converter.study = local_study_w_areas
         area_components = converter.convert_study_to_input_study()
         expected_area_components = InputStudy(

--- a/tests/unittests/study/test_components_parsing.py
+++ b/tests/unittests/study/test_components_parsing.py
@@ -7,7 +7,7 @@ from andromede.model.parsing import InputLibrary, parse_yaml_library
 from andromede.model.resolve_library import resolve_library
 from andromede.simulation import BlockBorderManagement, TimeBlock, build_problem
 from andromede.study import TimeScenarioIndex, TimeScenarioSeriesData
-from andromede.study.parsing import InputComponents, parse_yaml_components
+from andromede.study.parsing import InputStudy, parse_yaml_components
 from andromede.study.resolve_components import (
     build_data_base,
     build_network,
@@ -19,7 +19,7 @@ from andromede.study.resolve_components import (
 @pytest.fixture
 def input_component(
     data_dir: Path,
-) -> InputComponents:
+) -> InputStudy:
     compo_file = data_dir / "components.yml"
 
     with compo_file.open() as c:
@@ -37,7 +37,7 @@ def input_library(
 
 
 def test_parsing_components_ok(
-    input_component: InputComponents, input_library: InputLibrary
+    input_component: InputStudy, input_library: InputLibrary
 ) -> None:
     assert len(input_component.components) == 2
     assert len(input_component.nodes) == 1
@@ -51,7 +51,7 @@ def test_parsing_components_ok(
 
 
 def test_consistency_check_ok(
-    input_component: InputComponents, input_library: InputLibrary
+    input_component: InputStudy, input_library: InputLibrary
 ) -> None:
     result_lib = resolve_library([input_library])
     result_comp = resolve_components_and_cnx(input_component, result_lib)
@@ -59,7 +59,7 @@ def test_consistency_check_ok(
 
 
 def test_consistency_check_ko(
-    input_component: InputComponents, input_library: InputLibrary
+    input_component: InputStudy, input_library: InputLibrary
 ) -> None:
     result_lib = resolve_library([input_library])
     result_comp = resolve_components_and_cnx(input_component, result_lib)
@@ -72,7 +72,7 @@ def test_consistency_check_ko(
 
 
 def test_basic_balance_using_yaml(
-    input_component: InputComponents, input_library: InputLibrary
+    input_component: InputStudy, input_library: InputLibrary
 ) -> None:
     result_lib = resolve_library([input_library])
     components_input = resolve_components_and_cnx(input_component, result_lib)


### PR DESCRIPTION
Refactor the naming of input components to input study across the codebase for improved clarity and consistency. Update related functions and tests accordingly.