### PR TITLE
Allow to set class attributes by alias or field name

### DIFF
--- a/src/andromede/model/parsing.py
+++ b/src/andromede/model/parsing.py
@@ -13,8 +13,10 @@
 import typing
 from typing import List, Optional
 
-from pydantic import BaseModel, Field, ValidationError
+from pydantic import Field, ValidationError
 from yaml import safe_load
+
+from andromede.utils import ModifiedBaseModel, _to_kebab
 
 
 def parse_yaml_library(input: typing.TextIO) -> "InputLibrary":
@@ -23,17 +25,6 @@ def parse_yaml_library(input: typing.TextIO) -> "InputLibrary":
         return InputLibrary.model_validate(tree["library"])
     except ValidationError as e:
         raise ValueError(f"An error occurred during parsing: {e}")
-
-
-# Design note: actual parsing and validation is delegated to pydantic models
-def _to_kebab(snake: str) -> str:
-    return snake.replace("_", "-")
-
-
-class ModifiedBaseModel(BaseModel):
-    class Config:
-        alias_generator = _to_kebab
-        extra = "forbid"
 
 
 class InputParameter(ModifiedBaseModel):
@@ -50,10 +41,8 @@ class InputVariable(ModifiedBaseModel):
     upper_bound: Optional[str] = None
     variable_type: str = "float"
 
-    class Config:
-        alias_generator = _to_kebab
+    class Config(ModifiedBaseModel.Config):
         coerce_numbers_to_str = True
-        extra = "forbid"
 
 
 class InputConstraint(ModifiedBaseModel):

--- a/src/andromede/study/parsing.py
+++ b/src/andromede/study/parsing.py
@@ -18,8 +18,10 @@ from pathlib import Path
 from typing import List, Optional, Union
 
 import pandas as pd
-from pydantic import BaseModel, Field
+from pydantic import Field
 from yaml import safe_load
+
+from andromede.utils import ModifiedBaseModel
 
 
 def parse_yaml_components(input_study: typing.TextIO) -> "InputStudy":
@@ -32,47 +34,32 @@ def parse_scenario_builder(file: Path) -> pd.DataFrame:
     sb.rename(columns={0: "name", 1: "year", 2: "scenario"})
     return sb
 
-
-# Design note: actual parsing and validation is delegated to pydantic models
-def _to_kebab(snake: str) -> str:
-    return snake.replace("_", "-")
-
-
-class InputPortConnections(BaseModel):
+class InputPortConnections(ModifiedBaseModel):
     component1: str
     port1: str
     component2: str
     port2: str
 
 
-class InputComponentParameter(BaseModel):
+class InputComponentParameter(ModifiedBaseModel):
     id: str
     time_dependent: bool = False
     scenario_dependent: bool = False
     value: Union[float, str]
     scenario_group: Optional[str] = None
 
-    class Config:
-        alias_generator = _to_kebab
 
-
-class InputComponent(BaseModel):
+class InputComponent(ModifiedBaseModel):
     id: str
     model: str
     scenario_group: Optional[str] = None
     parameters: Optional[List[InputComponentParameter]] = None
 
-    class Config:
-        alias_generator = _to_kebab
 
-
-class InputStudy(BaseModel):
+class InputStudy(ModifiedBaseModel):
     nodes: List[InputComponent] = Field(default_factory=list)
     components: List[InputComponent] = Field(default_factory=list)
     connections: List[InputPortConnections] = Field(default_factory=list)
-
-    class Config:
-        alias_generator = _to_kebab
 
 
 @dataclass(frozen=True)

--- a/src/andromede/utils.py
+++ b/src/andromede/utils.py
@@ -17,6 +17,8 @@ import json
 import pathlib
 from typing import Any, Callable, Dict, Optional, TypeVar
 
+from pydantic import BaseModel
+
 T = TypeVar("T")
 K = TypeVar("K")
 V = TypeVar("V")
@@ -68,3 +70,15 @@ def read_json(filename: str, path: pathlib.Path) -> Dict[str, Any]:
     with (path / filename).open() as file:
         data = json.load(file)
     return data
+
+
+# Design note: actual parsing and validation is delegated to pydantic models
+def _to_kebab(snake: str) -> str:
+    return snake.replace("_", "-")
+
+
+class ModifiedBaseModel(BaseModel):
+    class Config:
+        alias_generator = _to_kebab
+        extra = "forbid"
+        populate_by_name = True


### PR DESCRIPTION
When parsing yaml, class attributes are populated by alias, however in tests we directly create such objects, that we populate by field name. We update pydantic rules to allow such behavior